### PR TITLE
Add video to the feed content

### DIFF
--- a/views/rss.latte
+++ b/views/rss.latte
@@ -12,7 +12,7 @@
 		{foreach $items as $item}
 			<item>
 				<title>{$item->desc}</title>
-				<description><![CDATA[{$item->desc}]]></description>
+				<description><![CDATA[<p>{$item->desc}</p><video controls="controls" preload="auto" src="{path('/stream?url=' . urlencode($item->video->playAddr))}"></video>]]></description>
 				<link>{path('/@' . $item->author->uniqueId . '/video/' . $item->id)}</link>
 				<pubDate>{date('r', $item->createTime)}</pubDate>
 				<guid isPermaLink="false">{$item->id}</guid>


### PR DESCRIPTION
When I tried using the RSS feed there was no video included in the content (I tried with NetNewsWire, Reeder and News Explorer). This is a solution that I based on different feeds that have videos