### PR TITLE
vt.tiktok.com + tiktok.com/t support in TikTok URL option

### DIFF
--- a/app/Controllers/RedirectController.php
+++ b/app/Controllers/RedirectController.php
@@ -52,7 +52,7 @@ class RedirectController {
      * to_endpoint maps a TikTok URL into a ProxiTok-compatible endpoint URL.
      */
     static private function to_endpoint(string $url): string {
-        if (preg_match('%^https://(?:vm|vt)+\.tiktok\.com/(?:t/)([A-Za-z0-9]+)%', $url, $m)) {
+        if (preg_match('%^(?:https?://|www\.)?(?:vm\.|vt\.)?tiktok\.com/(?:t/)?([A-Za-z0-9]+)%', $url, $m)) {
             // Short video URL
             return '/@placeholder/video/' . $m[1];
         } elseif (preg_match('%^https://www\.tiktok\.com/(.+)%', $url, $m)) {

--- a/app/Controllers/RedirectController.php
+++ b/app/Controllers/RedirectController.php
@@ -52,7 +52,7 @@ class RedirectController {
      * to_endpoint maps a TikTok URL into a ProxiTok-compatible endpoint URL.
      */
     static private function to_endpoint(string $url): string {
-        if (preg_match('%^https://vm\.tiktok\.com/([A-Za-z0-9]+)%', $url, $m)) {
+        if (preg_match('%^https://(?:vm|vt)+\.tiktok\.com/(?:t/)([A-Za-z0-9]+)%', $url, $m)) {
             // Short video URL
             return '/@placeholder/video/' . $m[1];
         } elseif (preg_match('%^https://www\.tiktok\.com/(.+)%', $url, $m)) {


### PR DESCRIPTION
Some explanation:
https://vm.tiktok.com/ZMNP7QUhy = https://vt.tiktok.com/ZMNP7QUhy = https://tiktok.com/t/ZMNP7QUhy

Also:
Support http, www or just `vm.tiktok.com/ZMNP7QUhy`

Some bugs:
`www.vm.tiktok.com/t/ZMNP7QUhy` is working, but don't think it is so bad