### PR TITLE
Introduce environment variable for scraper user agent

### DIFF
--- a/app/Helpers/Wrappers.php
+++ b/app/Helpers/Wrappers.php
@@ -99,6 +99,7 @@ class Wrappers {
     static public function api(): \TikScraper\Api {
         $method = Misc::env('API_SIGNER', '');
         $url = Misc::env('API_SIGNER_URL', '');
+        $user_agent = Misc::env('API_SIGNER_USERAGENT', '');
         if (!$method) {
             // Legacy support
             $browser_url = Misc::env('API_BROWSER_URL', '');
@@ -118,6 +119,10 @@ class Wrappers {
                 'close_when_done' => false
             ]
         ];
+
+        if ($user_agent) {
+            $options['user_agent'] = $user_agent;
+        }
 
         // -- PROXY CONFIG -- //
         $proxy_host = Misc::env('PROXY_HOST', '');
@@ -161,7 +166,6 @@ class Wrappers {
                     break;
             }
         }
-
         return new \TikScraper\Api($options, $cacheEngine);
     }
 }


### PR DESCRIPTION
This adds a `API_SIGNER_USERAGENT` environment variable which allows the user to specify the user agent that should be used for the scraper in the `.env` file:
```
# API CONFIG
API_SIGNER="remote"
API_SIGNER_URL="http://localhost:8080"
API_SIGNER_USERAGENT="Mozilla/5.0 (Linux; Android 11; SAMSUNG SM-G973U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/14.2 Chrome/87.0.4280.141 Mobile Safari/537.36"
```