### PR TITLE
Set page title to video description in video view

### DIFF
--- a/templates/views/video.latte
+++ b/templates/views/video.latte
@@ -4,6 +4,10 @@
 {var $og_content = $item->video->originCover}
 {var $og_url = url_video_internal($info->detail->uniqueId, $item->id)}
 
+{if !empty($item->desc)}
+	{var $title = trim($item->desc)}
+{/if}
+
 {block content}
 	<div class="columns is-centered is-vcentered is-gapless">
 		<div class="column has-text-centered">


### PR DESCRIPTION
If the upstream video has a description set, use it as the page title in place of "Video" in the video view. This helps to disambiguate video pages in the browser history.