### PR TITLE
harden docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,13 +18,47 @@ services:
     depends_on:
       - redis
       - signer
+    networks:
+      - proxitok
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETGID
+      - SETUID
+
   redis:
     container_name: proxitok-redis
     image: redis:7-alpine
     command: redis-server --save 60 1 --loglevel warning
     restart: unless-stopped
+    networks:
+      - proxitok
+    user: nobody
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /data:size=10M,mode=0770,uid=65534,gid=65534,noexec,nosuid,nodev
+    cap_drop:
+      - ALL
+
   signer:
     container_name: proxitok-signer
     image: ghcr.io/pablouser1/signtok:master
+    networks:
+      - proxitok
+    user: nobody
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
 volumes:
   proxitok-cache:
+
+networks:
+  proxitok:


### PR DESCRIPTION
This PR hardens the docker-compose file.

Docker Compose (renamed to docker-compose.yml): 
* `user`: this is set to the UID:GID of `nobody`, the least privileged account (except proxitok-web).
* `read_only`: this is set to true, this container doesn't write anything to the filesystem (except proxitok-web).
* `security_opt`: there's a lot of settings, but the important on is that the container doesn't get any privileges when asking for them.
* `cap_drop`: this drops ALL capabilities like CHOWN, SETUID, etc.
* `cap_add`: the container does need CHOWN, SETUID, SETGID, so we grant them to the containers.
* `networks`: this puts `proxitok` in its own separate bridge network where it cannot talk to other containers except the ones in the network.
* `tmpfs`: this makes a filesystem in RAM, so when it's restarted, the container volume is wiped.

