### PR TITLE
Adding script to sync/remember the playback volume 

### DIFF
--- a/scripts/video_volume.js
+++ b/scripts/video_volume.js
@@ -1,0 +1,40 @@
+// This will save the video volume and keep all the players on the page in sync
+document.addEventListener("DOMContentLoaded", function() {
+  const videos = document.querySelectorAll("video");
+
+  // Function to save the volume to localStorage
+  function saveVolume(volume) {
+    localStorage.setItem("videoVolume", volume);
+  }
+
+  // Function to restore the volume from localStorage
+  function restoreVolume() {
+    const savedVolume = localStorage.getItem("videoVolume");
+    if (savedVolume !== null) {
+      videos.forEach(video => {
+        video.volume = parseFloat(savedVolume);
+      });
+    }
+  }
+
+  // Function to sync the volume across all video elements
+  function syncVolume(video) {
+    videos.forEach(otherVideo => {
+      if (otherVideo !== video) {
+        otherVideo.volume = video.volume;
+      }
+    });
+    saveVolume(video.volume);
+  }
+
+  // Loop through all video elements and attach event listeners
+  videos.forEach(video => {
+    // Save the volume when the volume changes
+    video.addEventListener("volumechange", function() {
+      syncVolume(video);
+    });
+  });
+
+  // Restore the volume on page load
+  restoreVolume();
+});

--- a/templates/views/video.latte
+++ b/templates/views/video.latte
@@ -77,4 +77,5 @@
 			{/if}
 		</div>
 	</div>
+  <script src="{assets('js', 'video_volume.js')}"></script>
 {/block}


### PR DESCRIPTION
Currently every time you view a new video, the volume will be at 100%, even if you previously decreased it.

This change makes it so the volume gets stored to a localStorage variable (`videoVolume`), and then restored on a new access.

This also syncs the video volume across multiple `<video>` elements on a page.